### PR TITLE
Fix query params

### DIFF
--- a/test/fixtures/query-params.md
+++ b/test/fixtures/query-params.md
@@ -1,0 +1,7 @@
+# Query params
+
+Link to relative heading ![link](#query-params?foo=bar)
+
+Link to an ![image](./examples/image.jpg?foo=bar)
+
+And a file [link](./examples/github.md?foo=bar).

--- a/test/index.js
+++ b/test/index.js
@@ -524,5 +524,21 @@ test('remark-validate-links', function(t) {
     }, st.error)
   })
 
+  t.test('should support query parameters', function(st) {
+    st.plan(1)
+
+    execa(bin, [
+      '--no-config',
+      '--no-ignore',
+      '--use',
+      '../..=repository:"wooorm/test"',
+      '--use',
+      '../sort',
+      'query-params.md'
+    ]).then(function(result) {
+      st.equal(strip(result.stderr), [''].join('m'), 'should report')
+    }, st.error)
+  })
+
   t.end()
 })


### PR DESCRIPTION
I noticed urls with a query param weren't valid

For example:
https://github.com/remarkjs/remark-validate-links/blob/master/test/fixtures/examples/image.jpg?raw=true

I put together a failing test 👍 