### PR TITLE
Allow links to point to the top of the document

### DIFF
--- a/lib/find/config.js
+++ b/lib/find/config.js
@@ -6,6 +6,7 @@ module.exports = config
 
 var viewPaths = {github: 'blob', gitlab: 'blob', bitbucket: 'src'}
 var headingPrefixes = {github: '#', gitlab: '#', bitbucket: '#markdown-header-'}
+var topAnchors = {github: '#readme', gitlab: '#readme'}
 var lineLinks = {github: true, gitlab: true}
 
 function config(ctx) {
@@ -17,7 +18,13 @@ function config(ctx) {
     return
   }
 
-  urlConfig = {prefix: '', headingPrefix: '#', lines: false, hostname: null}
+  urlConfig = {
+    prefix: '',
+    headingPrefix: '#',
+    lines: false,
+    hostname: null,
+    topAnchor: null
+  }
 
   if (repo) {
     info = hostedGitInfo.fromUrl(repo)
@@ -34,6 +41,10 @@ function config(ctx) {
 
     if (info.type in lineLinks) {
       urlConfig.lines = lineLinks[info.type]
+    }
+
+    if (info.type in topAnchors) {
+      urlConfig.topAnchor = topAnchors[info.type]
     }
 
     urlConfig.hostname = info.domain

--- a/lib/find/find.js
+++ b/lib/find/find.js
@@ -167,6 +167,7 @@ function normalize(url, config) {
   var numberSignIndex = url.indexOf(numberSign)
   var lines = config.lines
   var prefix = config.headingPrefix
+  var topAnchor = config.topAnchor
   var filePath
   var hash
 
@@ -176,9 +177,13 @@ function normalize(url, config) {
     filePath = url.slice(0, numberSignIndex)
     hash = url.slice(numberSignIndex).toLowerCase()
 
+    // Ignore the hash if it references the top anchor of the environment
+    if (topAnchor && hash === topAnchor) {
+      hash = undefined
+    }
     // Ignore the hash if it references lines in a file or doesn’t start
     // with a heading prefix.
-    if (
+    else if (
       (lines && lineExpression.test(hash)) ||
       hash.slice(0, prefix.length) !== prefix
     ) {

--- a/test/fixtures/github.md
+++ b/test/fixtures/github.md
@@ -65,3 +65,7 @@ Valid: [b](http://example.com).
 Valid: [b](http://example.com/foo/bar/baz).
 
 Valid: [b](http://bitbucket.com/wooorm/test/blob/foo-bar/examples/world.md#hello).
+
+## Top Anchor
+
+This links to the start of the document [link](#readme).

--- a/test/fixtures/gitlab.md
+++ b/test/fixtures/gitlab.md
@@ -61,3 +61,7 @@ Valid: [b](http://example.com).
 Valid: [b](http://example.com/foo/bar/baz).
 
 Valid: [b](http://bitbucket.com/wooorm/test/blob/foo-bar/examples/world.md#hello).
+
+## Top Anchor
+
+This links to the start of the document [link](#readme).

--- a/test/index.js
+++ b/test/index.js
@@ -663,8 +663,9 @@ test('remark-validate-links', function(t) {
             '  49:10-49:40  warning  Link to unknown heading in `examples/world.md`: `hello`   missing-heading-in-file  remark-validate-links',
             '  51:10-51:38  warning  Link to unknown file: `examples/world.md`                 missing-file             remark-validate-links',
             '  51:10-51:38  warning  Link to unknown heading in `examples/world.md`: `hello`   missing-heading-in-file  remark-validate-links',
+            '  71:41-71:56  warning  Link to unknown heading: `readme`                         missing-heading          remark-validate-links',
             '',
-            '⚠ 14 warnings'
+            '⚠ 15 warnings'
           ].join('\n'),
           'should report'
         )


### PR DESCRIPTION
This PR enables linking to the top of a document on GitHub and Gitlab.

Both services have an anchor called `#readme` at the beginning of a rendered markdown document. This is useful for skipping the (potentially long) file list above it and it's heavily used in production (for example by `npm init` which appends it automatically if your package homepage is a GitHub repo).

BitBucket has no equivalent to this anchor, so this PR implements the feature as an environment-specific configuration.

I'll open this as a draft PR since I need clarification on the tests: I added a link pointing to `#readme` to each the `github.md` and the `gitlab.md`. They work as expected, however I added the same link to `bitbucket.md`, expecting it to fail, but it passed because it was tested as being in a GitHub environment.

Is there any mechanism in place to simulate BitBucket for tests?