### PR TITLE
Document that a different plugin checks references

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,8 +12,8 @@
 existing local files and headings.
 It does not check:
 
-* External URLs (see [`remark-lint-no-dead-urls`][no-dead-urls])
-* References (see [`remark-lint-no-undefined-references`][no-undef-refs])
+*   External URLs (see [`remark-lint-no-dead-urls`][no-dead-urls])
+*   References (see [`remark-lint-no-undefined-references`][no-undef-refs])
 
 For example, this document does not have a heading named `Hello`.
 So if we link to that (`[welcome](#hello)`), this plugin will warn about it.
@@ -96,14 +96,17 @@ Say we have the following file, `example.md`:
 ```markdown
 # Alpha
 
+Links are checked:
+
 This [exists](#alpha).
 This [one does not](#does-not).
 
 # Bravo
 
-Headings in `readme.md` are [not checked](readme.md#bravo).
-References are [not checked][foxtrot].
-But [missing files are reported](missing-example.js).
+Headings in `readme.md` are [checked](readme.md#nosuchheading).
+And [missing files are reported](missing-example.js).
+
+References are also checked:
 
 [alpha]: #alpha
 [charlie]: #charlie
@@ -128,11 +131,12 @@ Now, running `node example` yields:
 
 ```markdown
 example.md
-    4:6-4:31  warning  Link to unknown heading: `does-not`         missing-heading  remark-validate-links
-  10:5-10:53  warning  Link to unknown file: `missing-example.js`  missing-file     remark-validate-links
-  13:1-13:20  warning  Link to unknown heading: `charlie`          missing-heading  remark-validate-links
+     6:6-6:31  warning  Link to unknown heading: `does-not`                      missing-heading          remark-validate-links
+  10:29-10:63  warning  Link to unknown heading in `readme.md`: `nosuchheading`  missing-heading-in-file  remark-validate-links
+   11:5-11:53  warning  Link to unknown file: `missing-example.js`               missing-file             remark-validate-links
+   16:1-16:20  warning  Link to unknown heading: `charlie`                       missing-heading          remark-validate-links
 
-⚠ 3 warnings
+⚠ 4 warnings
 ```
 
 ## Configuration

--- a/readme.md
+++ b/readme.md
@@ -10,8 +10,10 @@
 
 [**remark**][remark] plugin to validate that Markdown links and images reference
 existing local files and headings.
-It does not check external URLs (see [`remark-lint-no-dead-urls`][no-dead-urls]
-for that).
+It does not check:
+
+* External URLs (see [`remark-lint-no-dead-urls`][no-dead-urls])
+* References (see [`remark-lint-no-undefined-references`][no-undef-refs])
 
 For example, this document does not have a heading named `Hello`.
 So if we link to that (`[welcome](#hello)`), this plugin will warn about it.
@@ -96,11 +98,11 @@ Say we have the following file, `example.md`:
 
 This [exists](#alpha).
 This [one does not](#does-not).
-References and definitions are [checked][alpha] [too][charlie].
 
 # Bravo
 
 Headings in `readme.md` are [not checked](readme.md#bravo).
+References are [not checked][foxtrot].
 But [missing files are reported](missing-example.js).
 
 [alpha]: #alpha
@@ -301,3 +303,5 @@ abide by its terms.
 [cwd]: https://github.com/vfile/vfile#vfilecwd
 
 [xss]: https://en.wikipedia.org/wiki/Cross-site_scripting
+
+[no-undef-refs]: https://github.com/remarkjs/remark-lint/tree/master/packages/remark-lint-no-undefined-references


### PR DESCRIPTION
Update the documentation, so that it's clear that a different plugin checks references. When I read the doc myself, that wasn't clear, and I mistakenly filed #52 against this plugin. 

/cc @ChristianMurphy 