### PR TITLE
Fix to ignore hash in images

### DIFF
--- a/lib/find/find.js
+++ b/lib/find/find.js
@@ -60,7 +60,7 @@ function find(ctx, next) {
     var data = node.data || {}
     var props = data.hProperties || {}
     var id = props.name || props.id || data.id
-    var info = node.url ? urlToPath(node.url, config) : null
+    var info = node.url ? urlToPath(node.url, config, node.type) : null
     var fp
     var hash
 
@@ -182,7 +182,7 @@ function find(ctx, next) {
   }
 }
 
-function urlToPath(value, config) {
+function urlToPath(value, config, nodeType) {
   var url
   var questionMarkIndex
   var numberSignIndex
@@ -230,7 +230,10 @@ function urlToPath(value, config) {
   numberSignIndex = value.indexOf(numberSign)
   questionMarkIndex = value.indexOf(questionMark)
 
-  if (
+  // Ignore "headings" in image links: `image.png#bordered`
+  if (numberSignIndex !== -1 && nodeType === 'image') {
+    value = value.slice(0, numberSignIndex)
+  } else if (
     questionMarkIndex !== -1 &&
     (numberSignIndex === -1 || numberSignIndex > questionMarkIndex)
   ) {

--- a/lib/find/find.js
+++ b/lib/find/find.js
@@ -182,7 +182,7 @@ function find(ctx, next) {
   }
 }
 
-function urlToPath(value, config, nodeType) {
+function urlToPath(value, config, type) {
   var url
   var questionMarkIndex
   var numberSignIndex
@@ -222,7 +222,10 @@ function urlToPath(value, config, nodeType) {
     // Currently, we’re ignoring this and just not supporting branches.
     value = value.split(slash).slice(1).join(slash)
 
-    return normalize(path.resolve(config.root, value + url.hash), config)
+    return normalize(
+      path.resolve(config.root, value + (type === 'image' ? '' : url.hash)),
+      config
+    )
   }
 
   // Remove the search: `?foo=bar`.
@@ -230,16 +233,19 @@ function urlToPath(value, config, nodeType) {
   numberSignIndex = value.indexOf(numberSign)
   questionMarkIndex = value.indexOf(questionMark)
 
-  // Ignore "headings" in image links: `image.png#bordered`
-  if (numberSignIndex !== -1 && nodeType === 'image') {
-    value = value.slice(0, numberSignIndex)
-  } else if (
+  if (
     questionMarkIndex !== -1 &&
     (numberSignIndex === -1 || numberSignIndex > questionMarkIndex)
   ) {
     value =
       value.slice(0, questionMarkIndex) +
       (numberSignIndex === -1 ? '' : value.slice(numberSignIndex))
+    numberSignIndex = value.indexOf(numberSign)
+  }
+
+  // Ignore "headings" in image links: `image.png#metadata`
+  if (numberSignIndex !== -1 && type === 'image') {
+    value = value.slice(0, numberSignIndex)
   }
 
   // Local: `#heading`.

--- a/test/fixtures/images.md
+++ b/test/fixtures/images.md
@@ -14,6 +14,8 @@ Absolute ![image reference][abs]
 
 Relative with whitespace ![image reference][rel-whitespace]
 
+Relative with heading ![image](./examples/image.jpg#metadata)
+
 <!-- Invalid: -->
 
 Relative ![missing image](./examples/missing.jpg)

--- a/test/fixtures/query-params.md
+++ b/test/fixtures/query-params.md
@@ -1,6 +1,6 @@
 # Query params
 
-Link to relative heading ![link](?foo=bar#query-params)
+Link to relative heading [link](?foo=bar#query-params)
 
 Link to an ![image](./examples/image.jpg?foo=bar)
 

--- a/test/fixtures/query-params.md
+++ b/test/fixtures/query-params.md
@@ -4,6 +4,8 @@ Link to relative heading [link](?foo=bar#query-params)
 
 Link to an ![image](./examples/image.jpg?foo=bar)
 
+Link to an ![image](./examples/image.jpg?foo=bar#client-params) with hash
+
 And a file [link](./examples/github.md?foo=bar).
 
 Question mark in hash (invalid) [link](#query-params?).

--- a/test/index.js
+++ b/test/index.js
@@ -1141,7 +1141,7 @@ test('remark-validate-links', function (t) {
           null,
           [
             'query-params.md',
-            '  9:33-9:55  warning  Link to unknown heading: `query-params?`. Did you mean `query-params`  missing-heading  remark-validate-links',
+            '  11:33-11:55  warning  Link to unknown heading: `query-params?`. Did you mean `query-params`  missing-heading  remark-validate-links',
             '',
             '⚠ 1 warning',
             ''

--- a/test/index.js
+++ b/test/index.js
@@ -1102,11 +1102,11 @@ test('remark-validate-links', function (t) {
           null,
           [
             'images.md',
-            '  19:10-19:50  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
-            '  21:12-21:42  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
-            '  23:10-23:89  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
-            '   35:1-35:38  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
-            '   37:1-37:77  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
+            '  21:10-21:50  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
+            '  23:12-23:42  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
+            '  25:10-25:89  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
+            '   37:1-37:38  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
+            '   39:1-39:77  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
             '',
             '⚠ 5 warnings',
             ''


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->

Hi!

The puprose of this feature is to fulfill following requirement:

**When linting image paths, hashes should be ignored just like question signs.**

AFAIK text after `#` sign in image sources are never used as a part of target but rather as an additinal data for resulting image. For example: https://www.xaprb.com/blog/how-to-style-images-with-markdown/ describes how to style images using content after `#` sign in image source. There is also use case in: https://www.gatsbyjs.com/plugins/gatsby-remark-image-attributes/ where `#content` is converted to `img` attributes in resulting HTML.

For example, currently if `image.png` file exists but we lint:

```markdown
![My image](./image.png#metadata)
```

There will be an error:

```
Link to unknown heading in `image.png`: `metadata`  missing-heading-in-file  remark-validate-links
```

Despite the fact, that the image exists and it will be rendered properly.

## Other changes

In this PR I also changed `test/fixtures/query-params.md`

```
Link to relative heading ![link](?foo=bar#query-params)
```

to

```
Link to relative heading [link](?foo=bar#query-params)
```

because it is a "Link" not "image", so this looks like a mistake (and prevented tests from working with my code).