### PR TITLE
Configure severity with unified-lint-rule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,10 @@ jobs:
         with:
           node-version: ${{matrix.node}}
       - run: npm install
+      - name: Cherry pick https://github.com/remarkjs/remark-lint/pull/283
+        run: |
+          curl https://patch-diff.githubusercontent.com/raw/remarkjs/remark-lint/pull/283.patch |
+          git apply -p 3 --ignore-space-change --directory node_modules/unified-lint-rule
       - run: npm test
       - uses: codecov/codecov-action@v1
     strategy:

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,6 +41,7 @@
  *   Otherwise, use `urlConfig` to specify this manually.
  */
 
+import {lintRule} from 'unified-lint-rule'
 import {check} from './check/index.js'
 import {find} from './find/index.js'
 import {constants} from './constants.js'
@@ -53,28 +54,39 @@ cliCompleter.pluginId = constants.sourceId
  *
  * @type {import('unified').Plugin<[Options?, FileSet?]|[Options?]|void[], Root>}
  */
-export default function remarkValidateLinks(options, fileSet) {
+export default function remarkValidateLinks(rawOptions, fileSet) {
   // Attach a `completer`.
   if (fileSet) {
     fileSet.use(cliCompleter)
   }
 
   // Find references and landmarks.
-  return (tree, file, next) => {
-    find.run(
-      {tree, file, fileSet, options: {...options}},
-      /** @type {Callback} */
-      (error) => {
-        if (error) {
-          next(error)
-        } else if (fileSet) {
-          next()
-        } else {
-          checkAll([file], next)
+  return lintRule(
+    {
+      origin: 'validate-links',
+      url: 'https://github.com/remarkjs/remark-validate-links#readme'
+    },
+    /** @type {import('unified-lint-rule').Rule<Root, Options>} */ (
+      tree,
+      file,
+      options,
+      next
+    ) => {
+      find.run(
+        {tree, file, fileSet, options: {...options}},
+        /** @type {Callback} */
+        (error) => {
+          if (error) {
+            next(error)
+          } else if (fileSet) {
+            next()
+          } else {
+            checkAll([file], next)
+          }
         }
-      }
-    )
-  }
+      )
+    }
+  ).call(this, rawOptions)
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,11 @@ cliCompleter.pluginId = constants.sourceId
  * Plugin to validate that Markdown links and images reference existing local
  * files and headings.
  *
- * @type {import('unified').Plugin<[Options?, FileSet?]|[Options?]|void[], Root>}
+ * @typedef {import('unified-lint-rule').Label|import('unified-lint-rule').Severity} Severity
+ * @type {import('unified').Plugin<[(Options|[Severity, Options?])?, FileSet?], Root>}
+ * https://github.com/microsoft/TypeScript/pull/48132
+ * @param [rawOptions]
+ * @param [fileSet]
  */
 export default function remarkValidateLinks(rawOptions, fileSet) {
   // Attach a `completer`.

--- a/test/index.js
+++ b/test/index.js
@@ -447,50 +447,37 @@ test('remark-validate-links', async (t) => {
   rimraf.sync('./.git')
 
   fs.renameSync('../../.git', '../../.git.bak')
-
-  try {
-    await exec(
-      [
-        bin,
-        '--no-config',
-        '--no-ignore',
-        '--use',
-        '../../index.js',
-        '--use',
-        '../sort.js',
-        'github.md'
-      ].join(' ')
-    )
-  } catch (error) {
-    const exception = /** @type {ExecError} */ (error)
-    fs.renameSync('../../.git.bak', '../../.git')
-    t.ok(
-      /not a git repository/i.test(String(exception)),
-      'should fail w/o Git repository'
-    )
-  }
+  ;({stderr} = await exec(
+    [
+      bin,
+      '--no-config',
+      '--no-ignore',
+      '--use',
+      '../../index.js',
+      '--use',
+      '../sort.js',
+      'github.md'
+    ].join(' ')
+  ))
+  fs.renameSync('../../.git.bak', '../../.git')
+  t.ok(/not a git repository/i.test(stderr), 'should fail w/o Git repository')
 
   await exec('git init')
-
-  try {
-    await exec(
-      [
-        bin,
-        '--no-config',
-        '--no-ignore',
-        '--use',
-        '../../index.js',
-        'github.md'
-      ].join(' ')
-    )
-  } catch (error) {
-    const exception = /** @type {ExecError} */ (error)
-    rimraf.sync('./.git')
-    t.ok(
-      /Could not find remote origin/.test(String(exception)),
-      'should fail w/o Git repository w/o remote'
-    )
-  }
+  ;({stderr} = await exec(
+    [
+      bin,
+      '--no-config',
+      '--no-ignore',
+      '--use',
+      '../../index.js',
+      'github.md'
+    ].join(' ')
+  ))
+  rimraf.sync('./.git')
+  t.ok(
+    /Could not find remote origin/.test(stderr),
+    'should fail w/o Git repository w/o remote'
+  )
 
   fs.renameSync('../../.git', '../../.git.bak')
   ;({stderr} = await exec(


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [ ] If applicable, I’ve added docs and tests

### Description of changes

What do you think about configuring the message severity in [the standard way](https://github.com/remarkjs/remark-lint#configure), using unified-lint-rule? e.g.
```js
remark().use(remarkValidateLinks, [
  "error",
  { repository: "https://github.com/remarkjs/remark-validate-links.git" },
]);
```

I wrapped the `remarkValidateLinks` transformer in `lintRule()` and pass it the raw options, maybe with a severity.

<!--do not edit: pr-->
