### PR TITLE
Add `url` to vfile messages

### DIFF
--- a/lib/check/validate.js
+++ b/lib/check/validate.js
@@ -133,9 +133,5 @@ function warn(ctx, reference) {
       origin
     )
     message.url = 'https://github.com/remarkjs/remark-validate-links#readme'
-
-    if (suggestion) {
-      message.expected = [suggestion]
-    }
   }
 }

--- a/lib/check/validate.js
+++ b/lib/check/validate.js
@@ -127,6 +127,15 @@ function warn(ctx, reference) {
   let index = -1
 
   while (++index < reference.nodes.length) {
-    reference.file.message(reason, reference.nodes[index], origin)
+    const message = reference.file.message(
+      reason,
+      reference.nodes[index],
+      origin
+    )
+    message.url = 'https://github.com/remarkjs/remark-validate-links#readme'
+
+    if (suggestion) {
+      message.expected = [suggestion]
+    }
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -41,6 +41,17 @@ test('remark-validate-links', async (t) => {
     ],
     'should work on the API'
   )
+  t.deepEqual(
+    vfile.messages.map((message) => message.url),
+    [
+      'https://github.com/remarkjs/remark-validate-links#readme',
+      'https://github.com/remarkjs/remark-validate-links#readme',
+      'https://github.com/remarkjs/remark-validate-links#readme',
+      'https://github.com/remarkjs/remark-validate-links#readme',
+      'https://github.com/remarkjs/remark-validate-links#readme'
+    ],
+    'should add message urls'
+  )
 
   const file = await remark()
     .use(links)
@@ -717,6 +728,16 @@ test('remark-validate-links', async (t) => {
       ''
     ].join('\n'),
     'should support a Bitbucket shortcode'
+  )
+
+  const withSuggestions = await remark()
+    .use(links)
+    .use(sort)
+    .process(readSync('suggestions.md'))
+  t.deepEqual(
+    withSuggestions.messages.map((message) => message.expected),
+    [['hello']],
+    'should support suggestions'
   )
   ;({stderr} = await exec(
     [

--- a/test/index.js
+++ b/test/index.js
@@ -729,16 +729,6 @@ test('remark-validate-links', async (t) => {
     ].join('\n'),
     'should support a Bitbucket shortcode'
   )
-
-  const withSuggestions = await remark()
-    .use(links)
-    .use(sort)
-    .process(readSync('suggestions.md'))
-  t.deepEqual(
-    withSuggestions.messages.map((message) => message.expected),
-    [['hello']],
-    'should support suggestions'
-  )
   ;({stderr} = await exec(
     [
       bin,


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This enhances the user experience in editors by adding a link to the project and providing the suggestion as a quick fix.

These are two separate features, but I combined them, because they touch the same lines.

<!--do not edit: pr-->
