### PR TITLE
Ignore hash (headings) in links to images even in references

### DIFF
--- a/lib/find/find-references.js
+++ b/lib/find/find-references.js
@@ -36,6 +36,25 @@ const lineExpression = /^#l\d/i
 const readmeExtensions = new Set(['.markdown', '.mdown', '.mkdn', '.md'])
 const readmeBasename = /^readme$/i
 
+const imageExtensions = Object.freeze([
+  'apng',
+  'bmp',
+  'gif',
+  'ico',
+  'jp2',
+  'jpeg',
+  'jpg',
+  'png',
+  'svg',
+  'tiff',
+  'webp',
+  'xbm',
+]);
+
+const imagePathRegexp = new RegExp(
+  `^(.*\/)?[^#]+\.(${imageExtensions.join('|')})(#.*|$)`
+);
+
 /**
  * @param {{tree: Root, file: VFile, fileSet?: FileSet, options: Options}} ctx
  */
@@ -217,6 +236,11 @@ export async function findReferences(ctx) {
  */
 // eslint-disable-next-line complexity
 function urlToPath(value, config, type) {
+  // Ignore "headings" in image links: `image.png#metadata`
+  if (isImagePath(value)) {
+    value = stripHash(value);
+  }
+
   // Absolute paths: `/wooorm/test/blob/main/directory/example.md`.
   if (value.charAt(0) === slash) {
     if (!config.urlConfig.hostname) {
@@ -277,7 +301,8 @@ function urlToPath(value, config, type) {
     numberSignIndex = value.indexOf(numberSign)
   }
 
-  // Ignore "headings" in image links: `image.png#metadata`
+  // Ignore "headings" in all image links: `image.png#metadata` (even if code removing
+  // hash from value didn't do that)
   if (numberSignIndex !== -1 && type === 'image') {
     value = value.slice(0, numberSignIndex)
   }
@@ -346,4 +371,20 @@ function readme(filePath) {
     readmeExtensions.has(ext) &&
     readmeBasename.test(path.basename(filePath, ext))
   )
+}
+
+/**
+ * 
+ * @param {string} path 
+ * @returns {boolean}
+ */
+function isImagePath(path) {
+  return imagePathRegexp.test(path);
+}
+
+/**
+ * @param {string} path 
+ */
+function stripHash(path) {
+  return path.replace(/^(.*?)(#.*)$/, '$1');
 }

--- a/lib/find/find-references.js
+++ b/lib/find/find-references.js
@@ -48,12 +48,12 @@ const imageExtensions = Object.freeze([
   'svg',
   'tiff',
   'webp',
-  'xbm',
-]);
+  'xbm'
+])
 
 const imagePathRegexp = new RegExp(
-  `^(.*\/)?[^#]+\.(${imageExtensions.join('|')})(#.*|$)`
-);
+  `^(.*/)?[^#]+\\.(${imageExtensions.join('|')})(#.*|$)`
+)
 
 /**
  * @param {{tree: Root, file: VFile, fileSet?: FileSet, options: Options}} ctx
@@ -238,7 +238,7 @@ export async function findReferences(ctx) {
 function urlToPath(value, config, type) {
   // Ignore "headings" in image links: `image.png#metadata`
   if (isImagePath(value)) {
-    value = stripHash(value);
+    value = stripHash(value)
   }
 
   // Absolute paths: `/wooorm/test/blob/main/directory/example.md`.
@@ -374,17 +374,17 @@ function readme(filePath) {
 }
 
 /**
- * 
- * @param {string} path 
+ *
+ * @param {string} path
  * @returns {boolean}
  */
 function isImagePath(path) {
-  return imagePathRegexp.test(path);
+  return imagePathRegexp.test(path)
 }
 
 /**
- * @param {string} path 
+ * @param {string} path
  */
 function stripHash(path) {
-  return path.replace(/^(.*?)(#.*)$/, '$1');
+  return path.replace(/^(.*?)(#.*)$/, '$1')
 }

--- a/test/fixtures/images.md
+++ b/test/fixtures/images.md
@@ -16,6 +16,8 @@ Relative with whitespace ![image reference][rel-whitespace]
 
 Relative with heading ![image](./examples/image.jpg#metadata)
 
+Relative reference with heading ![image reference][rel-heading]
+
 <!-- Invalid: -->
 
 Relative ![missing image](./examples/missing.jpg)
@@ -39,3 +41,5 @@ Absolute ![missing image reference][abs-missing]
 [abs-missing]: https://github.com/wooorm/test/blob/main/examples/missing.jpg
 
 [rel-whitespace]: "./examples/image with space.jpg"
+
+[rel-heading]: ./examples/image.jpg#metadata

--- a/test/index.js
+++ b/test/index.js
@@ -886,11 +886,11 @@ test('remark-validate-links', async (t) => {
     strip(stderr),
     [
       'images.md',
-      '  21:10-21:50  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
-      '  23:12-23:42  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
-      '  25:10-25:89  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
-      '   37:1-37:38  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
-      '   39:1-39:77  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
+      '  23:10-23:50  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
+      '  25:12-25:42  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
+      '  27:10-27:89  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
+      '   39:1-39:38  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
+      '   41:1-41:77  warning  Link to unknown file: `examples/missing.jpg`. Did you mean `examples/image.jpg`  missing-file  remark-validate-links',
       '',
       '⚠ 5 warnings',
       ''


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [X] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [X] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [X] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [X] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [X] If applicable, I’ve added docs and tests

### Description of changes

Hi!

The purpose of this feature is to fulfil the following requirement:

**When linting image paths in references, hashes should be ignored.**

This is follow-up for the PR merged a few years ago: https://github.com/remarkjs/remark-validate-links/pull/60

In that PR, I've implemented ignoring hashes in image paths written inline, but now we want to use separate references to images in our project and linter complains about these paths:

![obraz](https://github.com/remarkjs/remark-validate-links/assets/1345438/644cd7da-60b7-4450-9cb8-c3892f36a5c2)

In my PR https://github.com/remarkjs/remark-validate-links/pull/60 I've explained why hashes could be ignored in image paths.

I'm open to a discussion and looking forward for a reply :)

<!--do not edit: pr-->
